### PR TITLE
Ignore client connection closing - simpler challenge response error handling

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,8 +15,8 @@ services:
             max-size: 10m
         ports:
           - '3000:3000'
-        image: 856da056de3abb7b317e59481bd500c27eb0f3b2a4c2432e8db930c1d20e71bf
-        container_name: ssh-sync-server-debug
+        image: b44427a64de93c20123c068387b0adc0434434ba709fbd91dd03d33ade489c3e
+        container_name: sshdbg
     ssh-sync-db:
         image: therealpaulgg/ssh-sync-db:latest 
         container_name: ssh-sync-db-debug
@@ -26,17 +26,17 @@ services:
           - POSTGRES_DB=sshsync
         restart: always
     ssh-sync:
-        image: 9065faaa7a20a821f7323f42cbddac1b594f7d01d57f8b2a2837e433769b86f4
+        image: 62eab8fb32b34e0a2cf36e8635d810c20a38baa2d7beaf5b6918139339e23c23
         container_name: ssh-sync
         stdin_open: true # Allows Docker container to keep STDIN open
         tty: true # Allocates a pseudo-TTY
     ssh-sync-2:
-        image: 9065faaa7a20a821f7323f42cbddac1b594f7d01d57f8b2a2837e433769b86f4
+        image: 62eab8fb32b34e0a2cf36e8635d810c20a38baa2d7beaf5b6918139339e23c23
         container_name: ssh-sync-2
         stdin_open: true # Allows Docker container to keep STDIN open
         tty: true # Allocates a pseudo-TTY
     ssh-sync-3:
-        image: 9065faaa7a20a821f7323f42cbddac1b594f7d01d57f8b2a2837e433769b86f4
+        image: 62eab8fb32b34e0a2cf36e8635d810c20a38baa2d7beaf5b6918139339e23c23
         container_name: ssh-sync-3
         stdin_open: true # Allows Docker container to keep STDIN open
         tty: true # Allocates a pseudo-TTY


### PR DESCRIPTION
There were significant oversights in the pull request #17. 

While this code provided a great way of determining if the client indeed killed their session, there was a significant issue that arose, where this goroutine would read the first byte from the connection, causing any other readers which relied on this byte to effectively break themselves.

This code has been greatly simplified to, on the challenge responder side, simply check to see if we are receiving data from the channel (the channel closes, returning nil bytes). This was previously assuming any data obtained from the channel was in fact a byte array, which was false.

This code also resolves another bug, in which there was a goroutine reading from a channel from which the main thread was reading. While this code went unnoticed for a while, it was the cause of earlier panic issues (which were later obscured by concurrency bug fixes). The main channel always wins the race condition; but if it were to lose, this would result in a deadlock. The code has been simplified to have a channel created on the main thread, which the goroutine responds to either the timer expires or there is a message received from the Challenge Accepted channel (which other goroutines write to).